### PR TITLE
feat: Support https and insecure https for fetching status

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,6 @@
 import Config
 
+config :screen_checker,
+  screen_list_module: ScreenChecker.ScreenList
+
 import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,4 @@
 import Config
+
+config :screen_checker,
+  screen_list_module: ScreenChecker.FakeScreenList

--- a/lib/screen_checker/fake_screen_list.ex
+++ b/lib/screen_checker/fake_screen_list.ex
@@ -1,0 +1,5 @@
+defmodule ScreenChecker.FakeScreenList do
+  @moduledoc false
+
+  def fetch, do: []
+end

--- a/lib/screen_checker/fetch.ex
+++ b/lib/screen_checker/fetch.ex
@@ -5,16 +5,16 @@ defmodule ScreenChecker.Fetch do
   @headers []
   @opts [timeout: 2_000, recv_timeout: 15_000]
 
-  def fetch_status(ip) do
-    case fetch(ip) do
+  def fetch_status(ip, protocol) do
+    case fetch(ip, protocol) do
       {:ok, %{"Temperature" => -1, "Environment Light" => -1}} -> :asleep
       {:ok, %{"Temperature" => t}} -> {:up, t}
       other -> other
     end
   end
 
-  defp fetch(ip) do
-    with {:request, {:ok, response}} <- {:request, request(ip)},
+  defp fetch(ip, protocol) do
+    with {:request, {:ok, response}} <- {:request, request(ip, protocol)},
          %{status_code: 200, body: body} <- response,
          {:parse, {:ok, %{"Temperature" => _} = parsed}} <- {:parse, Jason.decode(body)} do
       {:ok, parsed}
@@ -26,7 +26,17 @@ defmodule ScreenChecker.Fetch do
     end
   end
 
-  defp request(ip) do
+  defp request(ip, :http) do
     HTTPoison.get("http://#{ip}/cgi-bin/getstatus.cgi", @headers, @opts)
+  end
+
+  defp request(ip, :https) do
+    HTTPoison.get("https://#{ip}/cgi-bin/getstatus.cgi", @headers, @opts)
+  end
+
+  defp request(ip, :https_insecure) do
+    opts = Keyword.put(@opts, :hackney, [:insecure])
+
+    HTTPoison.get("https://#{ip}/cgi-bin/getstatus.cgi", @headers, opts)
   end
 end

--- a/lib/screen_checker/screen_list.ex
+++ b/lib/screen_checker/screen_list.ex
@@ -26,7 +26,6 @@ defmodule ScreenChecker.ScreenList do
   end
 
   defp parse_screens(screens_json) do
-    # JSON string of the form `[[ip, name], ...]` expected
     case Jason.decode(screens_json) do
       {:ok, screens} ->
         Enum.map(screens, &parse_screen/1)

--- a/lib/screen_checker/screen_list.ex
+++ b/lib/screen_checker/screen_list.ex
@@ -7,7 +7,7 @@ defmodule ScreenChecker.ScreenList do
   {"ip": string, "name": string, "protocol"?: "http" | "https" | "https_insecure"}
   ```
 
-  `protocol` defaults to `"https"` if not set.
+  `protocol` defaults to `"http"` if not set.
   """
 
   require Logger

--- a/lib/screen_checker/screen_list.ex
+++ b/lib/screen_checker/screen_list.ex
@@ -1,0 +1,56 @@
+defmodule ScreenChecker.ScreenList do
+  @moduledoc """
+  Functions to fetch and parse the screen list config from an env var containing a JSON string.
+
+  Screen list is expected to be an array of objects of the form:
+  ```ts
+  {"ip": string, "name": string, "protocol"?: "http" | "https" | "https_insecure"}
+  ```
+
+  `protocol` defaults to `"https"` if not set.
+  """
+
+  require Logger
+
+  @screens_env_var "SCREEN_LIST"
+
+  def fetch do
+    @screens_env_var
+    |> System.get_env()
+    |> parse_screens()
+  end
+
+  defp parse_screens(nil) do
+    Logger.warn("#{@screens_env_var} environment variable is not defined")
+    []
+  end
+
+  defp parse_screens(screens_json) do
+    # JSON string of the form `[[ip, name], ...]` expected
+    case Jason.decode(screens_json) do
+      {:ok, screens} ->
+        Enum.map(screens, &parse_screen/1)
+
+      {:error, _} ->
+        Logger.warn(
+          "Failed to parse screen IPs/names from #{@screens_env_var} environment variable"
+        )
+
+        []
+    end
+  end
+
+  defp parse_screen(%{"ip" => ip, "name" => name} = screen) do
+    {parse_protocol(screen), ip, name}
+  end
+
+  defp parse_protocol(screen) do
+    screen
+    |> Map.get("protocol", "http")
+    |> case do
+      "http" -> :http
+      "https" -> :https
+      "https_insecure" -> :https_insecure
+    end
+  end
+end

--- a/lib/screen_checker/screen_list.ex
+++ b/lib/screen_checker/screen_list.ex
@@ -12,31 +12,31 @@ defmodule ScreenChecker.ScreenList do
 
   require Logger
 
-  @screens_env_var "SCREEN_LIST"
+  @screen_list_env_var "SCREEN_LIST"
 
   def fetch do
-    @screens_env_var
-    |> System.get_env()
-    |> parse_screens()
-  end
-
-  defp parse_screens(nil) do
-    Logger.warn("#{@screens_env_var} environment variable is not defined")
-    []
-  end
-
-  defp parse_screens(screens_json) do
-    case Jason.decode(screens_json) do
-      {:ok, screens} ->
-        Enum.map(screens, &parse_screen/1)
-
-      {:error, _} ->
-        Logger.warn(
-          "Failed to parse screen IPs/names from #{@screens_env_var} environment variable"
-        )
-
+    case System.get_env(@screen_list_env_var) do
+      nil ->
+        Logger.warn("#{@screen_list_env_var} environment variable is not defined")
         []
+
+      screens_json ->
+        screens_json
+        |> Jason.decode()
+        |> parse_screens()
     end
+  end
+
+  defp parse_screens({:ok, screens}) do
+    Enum.map(screens, &parse_screen/1)
+  end
+
+  defp parse_screens({:error, _}) do
+    Logger.warn(
+      "Failed to parse screen IPs/names from #{@screen_list_env_var} environment variable"
+    )
+
+    []
   end
 
   defp parse_screen(%{"ip" => ip, "name" => name} = screen) do

--- a/test/screen_checker/fetch_test.exs
+++ b/test/screen_checker/fetch_test.exs
@@ -1,13 +1,36 @@
 defmodule ScreenChecker.FetchTest do
   use ExUnit.Case
+
   import Mock
   alias ScreenChecker.{Fetch, Ping}
 
   describe "fetch_status/1" do
     test "sends request to the correct url" do
       with_mock HTTPoison, get: fn _url, _headers, _opts -> :anything end do
-        _ = Fetch.fetch_status("1.2.3.4")
+        _ = Fetch.fetch_status("1.2.3.4", :http)
         assert_called(HTTPoison.get("http://1.2.3.4/cgi-bin/getstatus.cgi", :_, :_))
+      end
+    end
+
+    test "uses an https request when passed :https" do
+      with_mock HTTPoison, get: fn _, _, _ -> httpoison_ok(~s|{"Temperature":42}|) end do
+        _ = Fetch.fetch_status("1.2.3.4", :https)
+
+        assert_called(HTTPoison.get("https://1.2.3.4/cgi-bin/getstatus.cgi", :_, :_))
+      end
+    end
+
+    test "uses an insecure https request when passed :https_insecure" do
+      with_mock HTTPoison, get: fn _, _, _ -> httpoison_ok(~s|{"Temperature":42}|) end do
+        _ = Fetch.fetch_status("1.2.3.4", :https_insecure)
+
+        assert_called(
+          HTTPoison.get("https://1.2.3.4/cgi-bin/getstatus.cgi", :_,
+            hackney: [:insecure],
+            timeout: 2_000,
+            recv_timeout: 15_000
+          )
+        )
       end
     end
 
@@ -16,20 +39,20 @@ defmodule ScreenChecker.FetchTest do
         get: fn _url, _headers, _opts ->
           httpoison_ok(~s|{"Temperature":-1,"Environment Light":-1}|)
         end do
-        assert :asleep == Fetch.fetch_status("")
+        assert :asleep == Fetch.fetch_status("", :http)
       end
     end
 
     test ~s|returns {:up, temp} when response body has `"Temperature": temp` where temp != -1| do
       with_mock HTTPoison, get: fn _, _, _ -> httpoison_ok(~s|{"Temperature":42}|) end do
-        assert {:up, 42} == Fetch.fetch_status("")
+        assert {:up, 42} == Fetch.fetch_status("", :http)
       end
     end
 
     test "returns {:up, temp} when temperature is -1 C as long as environment light is not -1" do
       with_mock HTTPoison,
         get: fn _, _, _ -> httpoison_ok(~s|{"Temperature":-1,"Environment Light":180}|) end do
-        assert {:up, -1} == Fetch.fetch_status("")
+        assert {:up, -1} == Fetch.fetch_status("", :http)
       end
     end
 
@@ -38,25 +61,25 @@ defmodule ScreenChecker.FetchTest do
         {HTTPoison, [], get: fn _, _, _ -> {:error, :reason} end},
         {Ping, [], switch_pingable?: fn _ -> true end}
       ] do
-        assert {:connection_error, true} == Fetch.fetch_status("")
+        assert {:connection_error, true} == Fetch.fetch_status("", :http)
       end
     end
 
     test "returns {:bad_status, <status>} when a non-200 response was received" do
       with_mock HTTPoison, get: fn _, _, _ -> httpoison_ok("", 404) end do
-        assert {:bad_status, 404} == Fetch.fetch_status("")
+        assert {:bad_status, 404} == Fetch.fetch_status("", :http)
       end
     end
 
     test "returns :invalid_response when an unexpected response body was received" do
       with_mock HTTPoison, get: fn _, _, _ -> httpoison_ok(~s|{"SomethingElse":true}|) end do
-        assert :invalid_response == Fetch.fetch_status("")
+        assert :invalid_response == Fetch.fetch_status("", :http)
       end
     end
 
     test "returns :error in all other cases" do
       with_mock HTTPoison, get: fn _, _, _ -> :something_else end do
-        assert :error == Fetch.fetch_status("")
+        assert :error == Fetch.fetch_status("", :http)
       end
     end
   end


### PR DESCRIPTION
**Asana task**: [Update logging screen_checker to account for replaced FH Solaris](https://app.asana.com/0/1185117109217413/1199972220495623/f)

The updated Solari screens serve their status info only over https, with a bad/self-signed certificate.

This PR allows screen_checker to make its requests via secure or insecure https, in addition to the already supported http protocol. It will allow us to start logging the updated screens' statuses again.

The insecure requests do not pose a security risk (confirmed by Ian W.) because:
- they are made within the MBTA private network
- they fetch non-sensitive data
- the existing Solari screens already serve their status data in an insecure manner (over http), so this isn't really any worse 🤷‍♂️