### PR TITLE
fix: Get GDS password from env var at runtime rather than setting it during build

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,6 @@ import Config
 
 config :screen_checker,
   solari_screen_list_module: ScreenChecker.SolariScreenList,
-  gds_dms_username: "mbtadata@gmail.com",
-  gds_dms_password: System.get_env("GDS_DMS_PASSWORD")
+  gds_dms_username: "mbtadata@gmail.com"
 
 import_config "#{Mix.env()}.exs"

--- a/lib/screen_checker/gds_data/fetch.ex
+++ b/lib/screen_checker/gds_data/fetch.ex
@@ -43,7 +43,7 @@ defmodule ScreenChecker.GdsData.Fetch do
   defp do_get_token do
     params = %{
       "UserName" => Application.get_env(:screen_checker, :gds_dms_username),
-      "Password" => Application.get_env(:screen_checker, :gds_dms_password),
+      "Password" => System.get_env("GDS_DMS_PASSWORD"),
       "Company" => "M B T A",
       "AspxAutoDetectCookieSupport" => 1
     }

--- a/lib/screen_checker/gds_data/logger.ex
+++ b/lib/screen_checker/gds_data/logger.ex
@@ -8,7 +8,7 @@ defmodule ScreenChecker.GdsData.Logger do
     VendorLogger.log_data(
       &Fetch.fetch_data_for_current_day/0,
       :gds,
-      :gds_dms_password
+      "GDS_DMS_PASSWORD"
     )
   end
 end

--- a/lib/screen_checker/vendor_data/logger.ex
+++ b/lib/screen_checker/vendor_data/logger.ex
@@ -3,9 +3,9 @@ defmodule ScreenChecker.VendorData.Logger do
 
   require Logger
 
-  @spec log_data((() -> [map()]), atom(), atom()) :: :ok
+  @spec log_data((() -> [map()]), atom(), String.t()) :: :ok
   def log_data(fetch_fn, vendor_name, application_key) do
-    if not is_nil(Application.get_env(:screen_checker, application_key)) do
+    if not is_nil(System.get_env(application_key)) do
       case fetch_fn.() do
         {:ok, data} -> Enum.each(data, &log_screen_entry(&1, vendor_name))
         :error -> nil


### PR DESCRIPTION
The app is built and run in two separate steps on opstech3, and we want to be able to pass the GDS account password in as an env var at runtime via the screen_checker.xml file read by WinSW, not during build.

(Elixir 1.11 supports doing this more easily via config/runtime.exs, but we're stuck on 1.10 for now in opstech3)