### PR TITLE
fix: Null values from API

### DIFF
--- a/lib/screen_checker/mercury_data/fetch.ex
+++ b/lib/screen_checker/mercury_data/fetch.ex
@@ -44,8 +44,8 @@ defmodule ScreenChecker.MercuryData.Fetch do
       uptime: "Uptime",
       connect_reason: "ConnectReason",
       connectivity_used: "ConnectivityUsed",
-      last_image_time: "LastImage",
-      last_data_time: "LastData"
+      last_image_time: "last_image_time",
+      last_data_time: "last_data_time"
     }
     |> Enum.map(fn {name, status_key} -> {name, Map.get(status, status_key)} end)
     |> Enum.into(%{})


### PR DESCRIPTION
[[GL E-Ink] Update Mercury API logging to include custom fields](https://app.asana.com/0/1185117109217413/1201591198273010/f)

We were not looking for the correct values in API response so the values were null. Adjusted names so values are populated correctly.