### PR TITLE
Migrating off OPSTECH3, step 1: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+ARG ELIXIR_VERSION=1.12.3
+ARG ERLANG_VERSION=22.3
+ARG WINDOWS_VERSION=1809
+# See also: ERTS_VERSION in the from image below
+
+ARG BUILD_IMAGE=mbtatools/windows-elixir:$ELIXIR_VERSION-erlang-$ERLANG_VERSION-windows-$WINDOWS_VERSION
+ARG FROM_IMAGE=mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION
+
+FROM $BUILD_IMAGE as build
+
+ENV MIX_ENV=prod
+
+# log which version of Windows we're using
+RUN ver
+
+RUN mkdir C:\screen_checker
+
+WORKDIR C:\\screen_checker
+
+COPY mix.exs mix.lock ./
+RUN mix deps.get
+
+COPY config/config.exs config\\config.exs
+COPY config/prod.exs config\\prod.exs
+
+RUN mix deps.compile
+
+COPY lib lib
+# ^ anything else we need to copy?
+
+RUN mix release
+
+FROM $FROM_IMAGE
+ARG ERTS_VERSION=10.7
+
+USER ContainerAdministrator
+COPY --from=build C:\\Erlang\\vcredist_x64.exe vcredist_x64.exe
+RUN .\vcredist_x64.exe /install /quiet /norestart \
+    && del vcredist_x64.exe
+
+COPY --from=build C:\\screen_checker\\_build\\prod\\rel\\screen_checker C:\\screen_checker
+
+WORKDIR C:\\screen_checker
+
+# Ensure Erlang can run
+RUN dir && \
+    erts-%ERTS_VERSION%\bin\erl -noshell -noinput +V
+
+EXPOSE 8001
+# ^ Realtime_signs uses 80 instead
+
+CMD ["C:\\screen_checker\\bin\\screen_checker.bat", "start"]

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,3 +5,6 @@ config :screen_checker,
   gds_dms_username: "mbtadata@gmail.com"
 
 import_config "#{Mix.env()}.exs"
+
+config :logger,
+  backends: [:console]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,11 +1,1 @@
 import Config
-
-config :logger,
-  backends: [{Logger.Backend.Splunk, :splunk}, :console]
-
-config :logger, :splunk,
-  connector: Logger.Backend.Splunk.Output.Http,
-  host: 'https://http-inputs-mbta.splunkcloud.com/services/collector/event',
-  token: {:system, "SCREEN_CHECKER_SPLUNK_TOKEN"},
-  format: "$dateT$time [$level]$levelpad $metadata$message\n",
-  metadata: [:request_id]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,11 +1,2 @@
 import Config
 
-config :logger,
-  backends: [{Logger.Backend.Splunk, :splunk}, :console]
-
-config :logger, :splunk,
-  connector: Logger.Backend.Splunk.Output.Http,
-  host: 'https://http-inputs-mbta.splunkcloud.com/services/collector/event',
-  token: {:system, "PROD_SCREEN_CHECKER_SPLUNK_TOKEN"},
-  format: "$dateT$time [$level]$levelpad node=$node $metadata$message\n",
-  metadata: [:request_id]


### PR DESCRIPTION
Task in [Notion](https://www.notion.so/mbta-downtown-crossing/screen_checker-ddd18bf72064442fa384a278e2071cea).

Created dockerfile. Removed splunk logging. Tested locally using a VM. 

The prod & dev configs are essentially empty now, though removing them entirely in favor of just one `config.exs` gave me some build issues. Open to other options!