### PR TITLE
Chore: Update GitHub actions to use assumed role

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -5,14 +5,16 @@ on:
 jobs:
   Build:
     runs-on: windows-2019
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - uses: mbta/actions/build-push-ecr@v1
+      - uses: mbta/actions/build-push-ecr@v2
         id: build-push
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
   Deploy:
     needs: Build


### PR DESCRIPTION
This PR updates the deploy workflow to use v2 of the shared `build-push-ecr` and `deploy-ecs` actions. These updated actions assume an IAM role instead of relying on long-lasting AWS keys for an IAM user. 

Note there are still workflow uses in this repo, those will be addressed as part of a follow-up subtask. 