### PR TITLE
fix: Mercury V2 logs

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,4 @@
+import Config
+
+config :screen_checker,
+  mercury_v2_api_key: System.get_env("MERCURY_V2_API_KEY")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,4 +1,0 @@
-import Config
-
-config :screen_checker,
-  mercury_v2_api_key: System.get_env("MERCURY_V2_API_KEY")

--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -1,8 +1,6 @@
 defmodule ScreenChecker.MercuryData.V2.Fetch do
   @moduledoc false
 
-  require Logger
-
   import ScreenChecker.VendorData.Fetch, only: [make_and_parse_request: 5]
 
   @api_url_base "https://api.nexus.mercuryinnovation.com.au/API/mbta/devices"

--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -33,7 +33,7 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
     end
   end
 
-  defp get_api_key, do: System.get_env("MERCURY_API_KEY")
+  defp get_api_key, do: System.get_env("MERCURY_V2_API_KEY")
 
   defp fetch_device_info(device) do
     device_id = device["device_id"]

--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -9,17 +9,7 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
   @vendor_request_opts [hackney: [pool: :mercury_v2_api_pool]]
 
   def fetch_data do
-    api_key = get_api_key()
-    headers = [{"apiKey", api_key}]
-
-    msg =
-      if is_binary(api_key) and String.length(api_key) > 0 do
-        "MERCURY_V2_API_KEY is non-empty string"
-      else
-        "MERCURY_V2_API_KEY is not set"
-      end
-
-    Logger.info(msg)
+    headers = [{"apiKey", get_api_key()}]
 
     case make_and_parse_request(
            @api_url_base,

--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -5,12 +5,13 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
 
   @api_url_base "https://api.nexus.mercuryinnovation.com.au/API/mbta/devices"
   @vendor_request_opts [hackney: [pool: :mercury_v2_api_pool]]
-  @headers [{"apiKey", System.get_env("MERCURY_V2_API_KEY")}]
 
   def fetch_data do
+    headers = [{"apiKey", Application.get_env(:screen_checker, :mercury_v2_api_key)}]
+
     case make_and_parse_request(
            @api_url_base,
-           @headers,
+           headers,
            &Jason.decode/1,
            :mercury_v2,
            @vendor_request_opts
@@ -25,7 +26,7 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
 
     case make_and_parse_request(
            @api_url_base <> "/#{device_id}",
-           @headers,
+           headers,
            &Jason.decode/1,
            :mercury_v2,
            @vendor_request_opts

--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -1,13 +1,25 @@
 defmodule ScreenChecker.MercuryData.V2.Fetch do
   @moduledoc false
 
+  require Logger
+
   import ScreenChecker.VendorData.Fetch, only: [make_and_parse_request: 5]
 
   @api_url_base "https://api.nexus.mercuryinnovation.com.au/API/mbta/devices"
   @vendor_request_opts [hackney: [pool: :mercury_v2_api_pool]]
 
   def fetch_data do
-    headers = [{"apiKey", Application.get_env(:screen_checker, :mercury_v2_api_key)}]
+    api_key = Application.get_env(:screen_checker, :mercury_v2_api_key)
+    headers = [{"apiKey", api_key}]
+
+    msg =
+      if is_binary(api_key) and String.length(api_key) > 0 do
+        "MERCURY_V2_API_KEY is non-empty string"
+      else
+        "MERCURY_V2_API_KEY is not set"
+      end
+
+    Logger.info(msg)
 
     case make_and_parse_request(
            @api_url_base,

--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -23,6 +23,7 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
 
   defp fetch_device_info(device) do
     device_id = device["device_id"]
+    headers = [{"apiKey", Application.get_env(:screen_checker, :mercury_v2_api_key)}]
 
     case make_and_parse_request(
            @api_url_base <> "/#{device_id}",

--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -9,7 +9,7 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
   @vendor_request_opts [hackney: [pool: :mercury_v2_api_pool]]
 
   def fetch_data do
-    api_key = Application.get_env(:screen_checker, :mercury_v2_api_key)
+    api_key = get_api_key()
     headers = [{"apiKey", api_key}]
 
     msg =
@@ -33,9 +33,11 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
     end
   end
 
+  defp get_api_key, do: System.get_env("MERCURY_API_KEY")
+
   defp fetch_device_info(device) do
     device_id = device["device_id"]
-    headers = [{"apiKey", Application.get_env(:screen_checker, :mercury_v2_api_key)}]
+    headers = [{"apiKey", get_api_key()}]
 
     case make_and_parse_request(
            @api_url_base <> "/#{device_id}",

--- a/lib/screen_checker/vendor_data/fetch.ex
+++ b/lib/screen_checker/vendor_data/fetch.ex
@@ -10,31 +10,36 @@ defmodule ScreenChecker.VendorData.Fetch do
       {:ok, parsed}
     else
       {:http_request, {:error, e}} ->
-        log_fetch_error(vendor_name, :http_fetch_error, %{message: HTTPoison.Error.message(e)})
+        log_fetch_error(
+          vendor_name,
+          :http_fetch_error,
+          %{message: HTTPoison.Error.message(e)},
+          url
+        )
 
       {:response_success, %{status_code: status_code}} ->
-        log_fetch_error(vendor_name, :bad_response_code, %{status_code: status_code})
+        log_fetch_error(vendor_name, :bad_response_code, %{status_code: status_code}, url)
 
       {:parse, _} ->
-        log_fetch_error(vendor_name, :parse_error)
+        log_fetch_error(vendor_name, :parse_error, url)
 
       _ ->
-        log_fetch_error(vendor_name, :error)
+        log_fetch_error(vendor_name, :error, url)
     end
   end
 
-  defp log_fetch_error(vendor_name, e) do
-    _ = Logger.info("#{vendor_name}_fetch_error #{e}")
+  defp log_fetch_error(vendor_name, e, url) do
+    _ = Logger.info("#{vendor_name}_fetch_error url=#{url} #{e}")
     :error
   end
 
-  defp log_fetch_error(vendor_name, e, data) do
+  defp log_fetch_error(vendor_name, e, data, url) do
     data_str =
       data
       |> Enum.map(fn {key, value} -> "#{key}=#{value}" end)
       |> Enum.join(" ")
 
-    _ = Logger.info("#{vendor_name}_fetch_error #{e} #{data_str}")
+    _ = Logger.info("#{vendor_name}_fetch_error url=#{url} #{e} #{data_str}")
     :error
   end
 end


### PR DESCRIPTION
The api key was not being retrieved correctly so requests were getting a 403. Moved around how we apply the key to headers.