### PR TITLE
fix: Mercury V2 API stop_id

### DIFF
--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -16,8 +16,17 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
            :mercury_v2,
            @vendor_request_opts
          ) do
-      {:ok, parsed} -> {:ok, Enum.map(parsed, &fetch_device_info/1)}
-      :error -> :error
+      {:ok, parsed} ->
+        prod_screens =
+          Enum.filter(parsed, fn
+            %{"stop" => %{"agency_id" => "mbta_prod"}} -> true
+            _ -> false
+          end)
+
+        {:ok, Enum.map(prod_screens, &fetch_device_info/1)}
+
+      :error ->
+        :error
     end
   end
 

--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -18,10 +18,7 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
          ) do
       {:ok, parsed} ->
         prod_screens =
-          Enum.filter(parsed, fn
-            %{"stop" => %{"agency_id" => "mbta_prod"}} -> true
-            _ -> false
-          end)
+          Enum.filter(parsed, &match?(%{"stop" => %{"agency_id" => "mbta_prod"}}, &1))
 
         {:ok, Enum.map(prod_screens, &fetch_device_info/1)}
 


### PR DESCRIPTION
The location of `stop_id` in the API changed and is causing all Mercury logs to fail. Unfortunately, this fix is making some assumptions on how this new `stop` object is shaped. Their latest API docs do not mention this new object at all. I still think the values are named in a way that makes this a safe assumption. Ana is making a note to bring this up to Mercury next week to confirm the assumption.