### PR TITLE
feat: log mercury button press counts

### DIFF
--- a/lib/screen_checker/gds_data/state.ex
+++ b/lib/screen_checker/gds_data/state.ex
@@ -5,7 +5,7 @@ defmodule ScreenChecker.GdsData.State do
 
   use ScreenChecker.VendorData.State
 
-  def do_log do
+  def do_log(_) do
     GdsLogger.log_data()
     :ok
   end

--- a/lib/screen_checker/mercury_data/v1/state.ex
+++ b/lib/screen_checker/mercury_data/v1/state.ex
@@ -5,7 +5,7 @@ defmodule ScreenChecker.MercuryData.V1.State do
 
   use ScreenChecker.VendorData.State
 
-  def do_log do
+  def do_log(_) do
     MercuryLoggerV1.log_data()
     :ok
   end

--- a/lib/screen_checker/mercury_data/v2/fetch.ex
+++ b/lib/screen_checker/mercury_data/v2/fetch.ex
@@ -3,14 +3,14 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
 
   import ScreenChecker.VendorData.Fetch, only: [make_and_parse_request: 5]
 
-  @api_url_base "https://api.nexus.mercuryinnovation.com.au/API/mbta/devices"
+  @api_url_base "https://api.nexus.mercuryinnovation.com.au/API/mbta"
   @vendor_request_opts [hackney: [pool: :mercury_v2_api_pool]]
 
-  def fetch_data do
+  def fetch_data(since) do
     headers = [{"apiKey", get_api_key()}]
 
     case make_and_parse_request(
-           @api_url_base,
+           @api_url_base <> "/devices",
            headers,
            &Jason.decode/1,
            :mercury_v2,
@@ -20,7 +20,13 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
         prod_screens =
           Enum.filter(parsed, &match?(%{"stop" => %{"agency_id" => "mbta_prod"}}, &1))
 
-        {:ok, Enum.map(prod_screens, &fetch_device_info/1)}
+        button_press_event_counts = fetch_button_press_events(prod_screens, since)
+
+        {:ok,
+         Enum.map(
+           prod_screens,
+           &fetch_device_info(&1, Map.get(button_press_event_counts, &1["device_id"], 0))
+         )}
 
       :error ->
         :error
@@ -29,20 +35,23 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
 
   defp get_api_key, do: System.get_env("MERCURY_V2_API_KEY")
 
-  defp fetch_device_info(device) do
+  defp fetch_device_info(device, num_button_presses) do
     device_id = device["device_id"]
     headers = [{"apiKey", get_api_key()}]
 
-    case make_and_parse_request(
-           @api_url_base <> "/#{device_id}",
-           headers,
-           &Jason.decode/1,
-           :mercury_v2,
-           @vendor_request_opts
-         ) do
-      {:ok, parsed} -> fetch_relevant_fields(parsed)
-      :error -> %{device_id: device_id, state: :error}
-    end
+    info =
+      case make_and_parse_request(
+             @api_url_base <> "/devices/#{device_id}",
+             headers,
+             &Jason.decode/1,
+             :mercury_v2,
+             @vendor_request_opts
+           ) do
+        {:ok, parsed} -> fetch_relevant_fields(parsed)
+        :error -> %{device_id: device_id, state: :error}
+      end
+
+    Map.put(info, :button_presses, num_button_presses)
   end
 
   defp fetch_relevant_fields(device) do
@@ -81,5 +90,34 @@ defmodule ScreenChecker.MercuryData.V2.Fetch do
       signal_strength: signal_strength,
       temperature: temperature
     }
+  end
+
+  defp fetch_button_press_events(devices, since) do
+    since = DateTime.to_unix(since)
+    now = DateTime.utc_now() |> DateTime.to_unix()
+    device_ids = Enum.map_join(devices, "-", & &1["device_id"])
+
+    case make_and_parse_request(
+           @api_url_base <> "/allEvents/#{device_ids}/#{since}/#{now}",
+           [{"apiKey", get_api_key()}],
+           &Jason.decode/1,
+           :mercury_v2,
+           @vendor_request_opts
+         ) do
+      {:ok, parsed} ->
+        for {device_id, events_map} <- parsed, into: %{} do
+          num_button_presses =
+            events_map
+            |> Map.values()
+            |> Enum.map(&Map.get(&1, "BUTTON_PRESS", []))
+            |> Enum.concat()
+            |> Enum.count()
+
+          {device_id, num_button_presses}
+        end
+
+      _ ->
+        %{}
+    end
   end
 end

--- a/lib/screen_checker/mercury_data/v2/logger.ex
+++ b/lib/screen_checker/mercury_data/v2/logger.ex
@@ -4,9 +4,9 @@ defmodule ScreenChecker.MercuryData.V2.Logger do
   alias ScreenChecker.MercuryData.V2.Fetch
   alias ScreenChecker.VendorData.Logger, as: VendorLogger
 
-  def log_data do
+  def log_data(since) do
     VendorLogger.log_data(
-      &Fetch.fetch_data/0,
+      fn -> Fetch.fetch_data(since) end,
       :mercury_v2,
       "MERCURY_V2_API_KEY"
     )

--- a/lib/screen_checker/mercury_data/v2/state.ex
+++ b/lib/screen_checker/mercury_data/v2/state.ex
@@ -5,8 +5,8 @@ defmodule ScreenChecker.MercuryData.V2.State do
 
   use ScreenChecker.VendorData.State
 
-  def do_log do
-    MercuryLoggerV2.log_data()
+  def do_log(since) do
+    MercuryLoggerV2.log_data(since)
     :ok
   end
 end

--- a/lib/screen_checker/vendor_data/state.ex
+++ b/lib/screen_checker/vendor_data/state.ex
@@ -19,17 +19,20 @@ defmodule ScreenChecker.VendorData.State do
       @impl true
       def init(:ok) do
         Logger.info("Started #{__MODULE__}")
+        state = DateTime.utc_now()
         schedule_refresh(self(), ScreenChecker.Time.next_minute_ms())
-        {:ok, nil}
+        {:ok, state}
       end
 
       @impl true
-      def handle_info(:refresh, state) do
+      def handle_info(:refresh, old_state) do
         Logger.info("#{__MODULE__}: Logging status")
-        _ = Task.start(&do_log/0)
+        new_state = DateTime.utc_now()
+
+        _ = Task.start(fn -> do_log(old_state) end)
 
         schedule_refresh(self(), ScreenChecker.Time.next_minute_ms())
-        {:noreply, state}
+        {:noreply, new_state}
       end
 
       # Handle leaked :ssl_closed messages from Hackney.


### PR DESCRIPTION
Adds some state to the vendor data gen server to track the last time data was fetched/logged. Uses that timestamp to fetch all button events since the last log and merges those counts into the existing mercury v2 logging.

**Asana:** [Add Mercury audio logging to Splunk](https://app.asana.com/0/1164574158255689/1207159385117966/f)