### PR TITLE
read logs from new GDS server

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -1,4 +1,5 @@
 # export MERCURY_API_KEY=
 # export MERCURY_V2_API_KEY=
+# export GDS_DMS_USERNAME=
 # export GDS_DMS_PASSWORD=
 # export SOLARI_SCREEN_LIST=

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,8 +1,7 @@
 import Config
 
 config :screen_checker,
-  solari_screen_list_module: ScreenChecker.SolariScreenList,
-  gds_dms_username: "mbtadata@gmail.com"
+  solari_screen_list_module: ScreenChecker.SolariScreenList
 
 config :logger,
   backends: [:console]


### PR DESCRIPTION
[New GDS server to query for logging reports](https://app.asana.com/0/1185117109217413/1209018090523765/f)

This changes over to the new GDS server for logging screen status. The new server returns dates and numbers in US formats, so the parsing needs to change slightly.

Note that before we deploy this, we'll need to file a ticket with infra to update the environment variable with the new password.